### PR TITLE
Credential Schema: remove todo's for 1.0 version

### DIFF
--- a/spec/proof-of-age.md
+++ b/spec/proof-of-age.md
@@ -13,11 +13,6 @@ The objective is to generate a general purpose age schema which should allow for
   - Police clearance / Criminal background or similar use cases in child care contexts
 :::
 
-::: todo proof of age issuance guidance
-  To do for version 2.0 of the Proof of Age schema spec:
-  Need to provide guidance on credential issuance for single vs. batch
-:::
-
 ![proof of age fields overview diagram](images/proof-of-age.png)
 
 #### Proof of Age Abstract Data Model
@@ -90,8 +85,3 @@ Object used to indicate a user is in a given in age range for example: between "
 #### Sample implementations of this schema standard
 
 - DIF: [Proof of Age Schema](https://github.com/decentralized-identity/credential-schemas/tree/main/dif-draft-schemas/proof-of-age-schema)
-
-
-::: todo add links to schema implementations
-  Need to add links to additional schema implementations in JSON-LD, SD-JWT and others
-:::

--- a/spec/verified-person.md
+++ b/spec/verified-person.md
@@ -232,7 +232,3 @@ Please see below for how the Verified Person maps to the [ISO Mobile Drivers Lic
 - DIF: [Verified Person Schema](https://github.com/decentralized-identity/credential-schemas/tree/main/dif-draft-schemas/basic-person-schema)
 - Privado ID (JSON-LD): [basic person](https://tools.privado.id/schemas/a6405ff0-ed9e-4bfb-bf75-6045aa4acd20)
 - Oasis [Lightweight Verifiable Credential Schema & Process](https://docs.oasis-open.org/lvcsp/lvcs/v1.0/cs01/lvcs-v1.0-cs01.pdf)
-
-::: todo add links to schema implementations
-  Need to add links to additional schema implementations in JSON-LD, SD-JWT and others
-:::


### PR DESCRIPTION
This PR removes the TODO sections, per feedback received from the DIF steering committee. The TODOs that were present were mostly reminders of future work.