### PR TITLE
feat: add media-provenance-capture and WordPress wpai-monitor-record schemas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,6 @@
 /community-schemas/OpenVerifiable/* @lnispel
 /community-schemas/OriginVault/* @lnispel
 /community-schemas/VelocityNetwork/* @vmc-crossmint @ottomorac @sloops77
+/community-schemas/WordPress/* @lnispel
 /community-schemas/cheqd/* @tweeddalex @ankurdotb
 /community-schemas/schemasWorkingGroup/* @vmc-crossmint @ottomorac @kimdhamilton

--- a/community-schemas/OpenVerifiable/schemas/media-provenance-capture/README.md
+++ b/community-schemas/OpenVerifiable/schemas/media-provenance-capture/README.md
@@ -1,0 +1,18 @@
+# Media Provenance Capture
+
+**Subject-only** JSON Schema and JSON-LD context for a read-only **intake-time** capture of C2PA manifest presence and related file metadata. Use as the payload for `credentialSubject` when wrapping in a [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model/); do not embed credential envelope properties (`issuer`, `proof`, etc.) in this document.
+
+- **JSON Schema:** [`schema.json`](./schema.json) — machine validation of the record shape.
+- **JSON-LD context:** [`context.json`](./context.json) — maps field names to [Schema.org](https://schema.org/) and OpenVerifiable vocabulary where applicable.
+
+**CMS-agnostic:** no WordPress- or host-specific IDs. For the WordPress plugin postmeta shape, see [`../../../WordPress/schemas/wpai-monitor-record/`](../../../WordPress/schemas/wpai-monitor-record/README.md).
+
+## Consuming `errors`
+
+Each `errors[]` item should be interpreted as `schema:CreateAction` / `schema:InformAction` style diagnostics; JSON-LD term definitions for per-item `stage` and `message` are left to the issuing profile when this record is placed in a VC.
+
+## `$id` resolution
+
+After merge to `main` on the DIF [credential-schemas](https://github.com/decentralized-identity/credential-schemas) repository, `schema.json` resolves at:
+
+`https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/OpenVerifiable/schemas/media-provenance-capture/schema.json`

--- a/community-schemas/OpenVerifiable/schemas/media-provenance-capture/context.json
+++ b/community-schemas/OpenVerifiable/schemas/media-provenance-capture/context.json
@@ -1,0 +1,41 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"@protected": true,
+		"xsd": "http://www.w3.org/2001/XMLSchema#",
+		"schema": "https://schema.org/",
+		"ov": "https://openverifiable.ai/vocab#",
+		"captured_at": { "@id": "schema:uploadDate", "@type": "xsd:dateTime" },
+		"source": {
+			"@id": "ov:mediaSource",
+			"@context": {
+				"mime": "schema:encodingFormat",
+				"size_bytes": { "@id": "schema:contentSize", "@type": "xsd:nonNegativeInteger" },
+				"original_path_relative": { "@id": "schema:contentUrl" }
+			}
+		},
+		"traditional": {
+			"@id": "ov:traditionalMetadata",
+			"@context": {
+				"exif": "schema:exifData",
+				"iptc": "ov:iptcMetadata",
+				"xmp": "ov:xmpMetadata"
+			}
+		},
+		"c2pa": {
+			"@id": "ov:c2paCapture",
+			"@context": {
+				"present": { "@id": "ov:manifestStorePresent" },
+				"format": "ov:imageContainerFormat",
+				"container": "ov:manifestContainerLabel",
+				"manifest_sha256": "schema:sha256",
+				"manifest_length": { "@id": "schema:fileSize" },
+				"sidecar_path_relative": "ov:sidecarRelativePath",
+				"decoded": "ov:decodedC2paManifest"
+			}
+		},
+		"errors": { "@id": "ov:captureErrorLog" },
+		"stage": "ov:errorStage",
+		"message": "schema:description"
+	}
+}

--- a/community-schemas/OpenVerifiable/schemas/media-provenance-capture/context.json
+++ b/community-schemas/OpenVerifiable/schemas/media-provenance-capture/context.json
@@ -4,10 +4,10 @@
 		"@protected": true,
 		"xsd": "http://www.w3.org/2001/XMLSchema#",
 		"schema": "https://schema.org/",
-		"ov": "https://openverifiable.ai/vocab#",
+		"ove": "https://openverifiable.ai/vocab#",
 		"captured_at": { "@id": "schema:uploadDate", "@type": "xsd:dateTime" },
 		"source": {
-			"@id": "ov:mediaSource",
+			"@id": "ove:mediaSource",
 			"@context": {
 				"mime": "schema:encodingFormat",
 				"size_bytes": { "@id": "schema:contentSize", "@type": "xsd:nonNegativeInteger" },
@@ -15,27 +15,27 @@
 			}
 		},
 		"traditional": {
-			"@id": "ov:traditionalMetadata",
+			"@id": "ove:traditionalMetadata",
 			"@context": {
 				"exif": "schema:exifData",
-				"iptc": "ov:iptcMetadata",
-				"xmp": "ov:xmpMetadata"
+				"iptc": "ove:iptcMetadata",
+				"xmp": "ove:xmpMetadata"
 			}
 		},
 		"c2pa": {
-			"@id": "ov:c2paCapture",
+			"@id": "ove:c2paCapture",
 			"@context": {
-				"present": { "@id": "ov:manifestStorePresent" },
-				"format": "ov:imageContainerFormat",
-				"container": "ov:manifestContainerLabel",
+				"present": { "@id": "ove:manifestStorePresent" },
+				"format": "ove:imageContainerFormat",
+				"container": "ove:manifestContainerLabel",
 				"manifest_sha256": "schema:sha256",
 				"manifest_length": { "@id": "schema:fileSize" },
-				"sidecar_path_relative": "ov:sidecarRelativePath",
-				"decoded": "ov:decodedC2paManifest"
+				"sidecar_path_relative": "ove:sidecarRelativePath",
+				"decoded": "ove:decodedC2paManifest"
 			}
 		},
-		"errors": { "@id": "ov:captureErrorLog" },
-		"stage": "ov:errorStage",
+		"errors": { "@id": "ove:captureErrorLog" },
+		"stage": "ove:errorStage",
 		"message": "schema:description"
 	}
 }

--- a/community-schemas/OpenVerifiable/schemas/media-provenance-capture/schema.json
+++ b/community-schemas/OpenVerifiable/schemas/media-provenance-capture/schema.json
@@ -1,0 +1,65 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/OpenVerifiable/schemas/media-provenance-capture/schema.json",
+	"title": "Media Provenance Capture",
+	"description": "Subject-only capture record: structured metadata and raw C2PA manifest presence detected in a media file at intake time. For use as credentialSubject data or in CMS storage; no Verifiable Credential envelope.",
+	"type": "object",
+	"properties": {
+		"captured_at": {
+			"type": "string",
+			"format": "date-time",
+			"description": "When the capture run completed (ISO 8601, UTC Z recommended)."
+		},
+		"source": { "$ref": "#/$defs/source" },
+		"traditional": { "$ref": "#/$defs/traditional" },
+		"c2pa": { "$ref": "#/$defs/c2pa" },
+		"errors": { "$ref": "#/$defs/errors" }
+	},
+	"required": [ "captured_at", "source", "traditional", "c2pa", "errors" ],
+	"additionalProperties": true,
+	"$defs": {
+		"source": {
+			"type": "object",
+			"description": "The assessed media asset. Maps to schema:ImageObject / schema:MediaObject fields; see context.json.",
+			"properties": {
+				"mime": { "type": "string", "description": "IANA media type (e.g. image/jpeg)." },
+				"size_bytes": { "type": "integer", "minimum": 0 },
+				"original_path_relative": {
+					"type": "string",
+					"description": "Path to the file relative to a storage root, or an absolute path if outside that root."
+				}
+			}
+		},
+		"traditional": {
+			"type": "object",
+			"description": "Reserved for EXIF / IPTC / XMP promotions from the host environment (often empty in early phases).",
+			"properties": {
+				"exif": { "type": "object", "additionalProperties": true },
+				"iptc": { "type": "object", "additionalProperties": true },
+				"xmp": { "type": "object", "additionalProperties": true }
+			}
+		},
+		"c2pa": {
+			"type": "object",
+			"description": "C2PA manifest store detection result (read-only; no cryptographic verification in baseline).",
+			"properties": {
+				"present": { "type": "boolean" },
+				"format": { "type": [ "string", "null" ] },
+				"container": { "type": "string" },
+				"manifest_sha256": { "type": "string", "description": "Lowercase hex SHA-256 of the raw manifest store bytes." },
+				"manifest_length": { "type": "integer", "minimum": 0 },
+				"sidecar_path_relative": { "type": "string" },
+				"decoded": { "type": [ "object", "null" ] }
+			}
+		},
+		"errorItem": {
+			"type": "object",
+			"properties": {
+				"stage": { "type": "string" },
+				"message": { "type": "string" }
+			},
+			"required": [ "stage", "message" ]
+		},
+		"errors": { "type": "array", "items": { "$ref": "#/$defs/errorItem" } }
+	}
+}

--- a/community-schemas/WordPress/CODEOWNERS
+++ b/community-schemas/WordPress/CODEOWNERS
@@ -1,0 +1,4 @@
+# The following owner is responsible for the WordPress folder
+# in the DIF community-schemas repository.
+
+*  @lnispel

--- a/community-schemas/WordPress/README.md
+++ b/community-schemas/WordPress/README.md
@@ -1,0 +1,8 @@
+# WordPress (community schemas)
+
+This folder contains **JSON Schema** and **JSON-LD** definitions for data shapes used by the [WordPress AI / AI plugin](https://github.com/WordPress/ai) ecosystem, contributed for public reuse. Schemas are **subject-only** (suitable for `credentialSubject`); the Verifiable Credential wrapper is applied at issuance time, not in these files.
+
+- Each schema lives in its own subfolder with `schema.json` and `context.json`.
+- Shared provenance concepts may `$ref` [OpenVerifiable](https://github.com/decentralized-identity/credential-schemas/tree/main/community-schemas/OpenVerifiable) subject schemas and extend them with WordPress-specific fields (e.g. attachment IDs, sidecar paths under `wp-content/uploads`).
+
+See individual `schemas/*/README.md` files for details.

--- a/community-schemas/WordPress/schemas/wpai-monitor-record/README.md
+++ b/community-schemas/WordPress/schemas/wpai-monitor-record/README.md
@@ -1,0 +1,16 @@
+# WPAI C2PA Monitor record
+
+JSON Schema and JSON-LD **subject** shape for the C2PA Monitor experiment in the WordPress AI plugin: the value stored as a JSON string in post meta key `_wpai_monitor_record`.
+
+- **JSON Schema:** [`schema.json`](./schema.json) — `allOf` the [OpenVerifiable `media-provenance-capture`](../../../OpenVerifiable/schemas/media-provenance-capture/schema.json) subject plus `schema_version`, `duration_ms`, and `source.attachment_id`.
+- **JSON-LD context:** [`context.json`](./context.json) — same logical fields; WordPress-specific terms use the `ov` vocabulary (see [OpenVerifiable](https://openverifiable.ai)).
+
+**Not** a Verifiable Credential — do not add `issuer`, `proof`, or `credentialSubject` to these files. Wrap at issuance time if needed.
+
+## Resolution
+
+`https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/schema.json`
+
+`https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/context.json`
+
+Refer to this schema from plugin PHP docblocks and READMEs as the canonical postmeta contract.

--- a/community-schemas/WordPress/schemas/wpai-monitor-record/README.md
+++ b/community-schemas/WordPress/schemas/wpai-monitor-record/README.md
@@ -3,7 +3,7 @@
 JSON Schema and JSON-LD **subject** shape for the C2PA Monitor experiment in the WordPress AI plugin: the value stored as a JSON string in post meta key `_wpai_monitor_record`.
 
 - **JSON Schema:** [`schema.json`](./schema.json) — `allOf` the [OpenVerifiable `media-provenance-capture`](../../../OpenVerifiable/schemas/media-provenance-capture/schema.json) subject plus `schema_version`, `duration_ms`, and `source.attachment_id`.
-- **JSON-LD context:** [`context.json`](./context.json) — same logical fields; WordPress-specific terms use the `ov` vocabulary (see [OpenVerifiable](https://openverifiable.ai)).
+- **JSON-LD context:** [`context.json`](./context.json) — same logical fields; WordPress-specific terms use the `ove` vocabulary prefix (`https://openverifiable.ai/vocab#`, see [OpenVerifiable](https://openverifiable.ai)).
 
 **Not** a Verifiable Credential — do not add `issuer`, `proof`, or `credentialSubject` to these files. Wrap at issuance time if needed.
 

--- a/community-schemas/WordPress/schemas/wpai-monitor-record/context.json
+++ b/community-schemas/WordPress/schemas/wpai-monitor-record/context.json
@@ -1,0 +1,42 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"@protected": true,
+		"xsd": "http://www.w3.org/2001/XMLSchema#",
+		"schema": "https://schema.org/",
+		"ov": "https://openverifiable.ai/vocab#",
+		"schema_version": { "@id": "ov:postmetaRecordSchemaVersion" },
+		"duration_ms": { "@id": "ov:captureDurationMs" },
+		"captured_at": { "@id": "schema:uploadDate", "@type": "xsd:dateTime" },
+		"source": {
+			"@id": "ov:mediaSource",
+			"@context": {
+				"attachment_id": { "@id": "ov:wordPressAttachmentId", "@type": "xsd:nonNegativeInteger" },
+				"mime": "schema:encodingFormat",
+				"size_bytes": { "@id": "schema:contentSize", "@type": "xsd:nonNegativeInteger" },
+				"original_path_relative": { "@id": "schema:contentUrl" }
+			}
+		},
+		"traditional": {
+			"@id": "ov:traditionalMetadata",
+			"@context": {
+				"exif": "schema:exifData",
+				"iptc": "ov:iptcMetadata",
+				"xmp": "ov:xmpMetadata"
+			}
+		},
+		"c2pa": {
+			"@id": "ov:c2paCapture",
+			"@context": {
+				"present": { "@id": "ov:manifestStorePresent" },
+				"format": "ov:imageContainerFormat",
+				"container": "ov:manifestContainerLabel",
+				"manifest_sha256": "schema:sha256",
+				"manifest_length": { "@id": "schema:fileSize" },
+				"sidecar_path_relative": { "@id": "ov:wordPressSidecarRelativePath" },
+				"decoded": "ov:decodedC2paManifest"
+			}
+		},
+		"errors": { "@id": "ov:captureErrorLog" }
+	}
+}

--- a/community-schemas/WordPress/schemas/wpai-monitor-record/context.json
+++ b/community-schemas/WordPress/schemas/wpai-monitor-record/context.json
@@ -4,39 +4,39 @@
 		"@protected": true,
 		"xsd": "http://www.w3.org/2001/XMLSchema#",
 		"schema": "https://schema.org/",
-		"ov": "https://openverifiable.ai/vocab#",
-		"schema_version": { "@id": "ov:postmetaRecordSchemaVersion" },
-		"duration_ms": { "@id": "ov:captureDurationMs" },
+		"ove": "https://openverifiable.ai/vocab#",
+		"schema_version": { "@id": "ove:postmetaRecordSchemaVersion" },
+		"duration_ms": { "@id": "ove:captureDurationMs" },
 		"captured_at": { "@id": "schema:uploadDate", "@type": "xsd:dateTime" },
 		"source": {
-			"@id": "ov:mediaSource",
+			"@id": "ove:mediaSource",
 			"@context": {
-				"attachment_id": { "@id": "ov:wordPressAttachmentId", "@type": "xsd:nonNegativeInteger" },
+				"attachment_id": { "@id": "ove:wordPressAttachmentId", "@type": "xsd:nonNegativeInteger" },
 				"mime": "schema:encodingFormat",
 				"size_bytes": { "@id": "schema:contentSize", "@type": "xsd:nonNegativeInteger" },
 				"original_path_relative": { "@id": "schema:contentUrl" }
 			}
 		},
 		"traditional": {
-			"@id": "ov:traditionalMetadata",
+			"@id": "ove:traditionalMetadata",
 			"@context": {
 				"exif": "schema:exifData",
-				"iptc": "ov:iptcMetadata",
-				"xmp": "ov:xmpMetadata"
+				"iptc": "ove:iptcMetadata",
+				"xmp": "ove:xmpMetadata"
 			}
 		},
 		"c2pa": {
-			"@id": "ov:c2paCapture",
+			"@id": "ove:c2paCapture",
 			"@context": {
-				"present": { "@id": "ov:manifestStorePresent" },
-				"format": "ov:imageContainerFormat",
-				"container": "ov:manifestContainerLabel",
+				"present": { "@id": "ove:manifestStorePresent" },
+				"format": "ove:imageContainerFormat",
+				"container": "ove:manifestContainerLabel",
 				"manifest_sha256": "schema:sha256",
 				"manifest_length": { "@id": "schema:fileSize" },
-				"sidecar_path_relative": { "@id": "ov:wordPressSidecarRelativePath" },
-				"decoded": "ov:decodedC2paManifest"
+				"sidecar_path_relative": { "@id": "ove:wordPressSidecarRelativePath" },
+				"decoded": "ove:decodedC2paManifest"
 			}
 		},
-		"errors": { "@id": "ov:captureErrorLog" }
+		"errors": { "@id": "ove:captureErrorLog" }
 	}
 }

--- a/community-schemas/WordPress/schemas/wpai-monitor-record/schema.json
+++ b/community-schemas/WordPress/schemas/wpai-monitor-record/schema.json
@@ -10,6 +10,11 @@
 		{
 			"type": "object",
 			"properties": {
+				"@context": {
+					"type": "array",
+					"items": { "type": "string", "format": "uri" },
+					"description": "JSON-LD context URLs. First entry is https://schema.org/; second is the wpai-monitor-record context.json. Present in every stored record; not required by schema validation since JSON Schema processors ignore JSON-LD keywords."
+				},
 				"schema_version": {
 					"type": "integer",
 					"minimum": 1,

--- a/community-schemas/WordPress/schemas/wpai-monitor-record/schema.json
+++ b/community-schemas/WordPress/schemas/wpai-monitor-record/schema.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/WordPress/schemas/wpai-monitor-record/schema.json",
+	"title": "WPAI C2PA Monitor record",
+	"description": "WordPress postmeta value for the C2PA Monitor experiment: JSON string at _wpai_monitor_record. Extends the OpenVerifiable media-provenance-capture subject with plugin-specific fields. Not a Verifiable Credential on its own.",
+	"allOf": [
+		{
+			"$ref": "https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/OpenVerifiable/schemas/media-provenance-capture/schema.json"
+		},
+		{
+			"type": "object",
+			"properties": {
+				"schema_version": {
+					"type": "integer",
+					"minimum": 1,
+					"description": "Increment on breaking postmeta record shape changes."
+				},
+				"duration_ms": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Wall time for the capture run, in milliseconds."
+				},
+				"source": {
+					"type": "object",
+					"allOf": [
+						{
+							"$ref": "https://raw.githubusercontent.com/decentralized-identity/credential-schemas/main/community-schemas/OpenVerifiable/schemas/media-provenance-capture/schema.json#/$defs/source"
+						},
+						{
+							"type": "object",
+							"properties": {
+								"attachment_id": {
+									"type": "integer",
+									"minimum": 0
+								}
+							},
+							"required": [ "attachment_id" ]
+						}
+					]
+				}
+			},
+			"required": [ "schema_version", "duration_ms" ]
+		}
+	]
+}


### PR DESCRIPTION
- OpenVerifiable: subject-only JSON Schema + JSON-LD context for CMS-agnostic C2PA intake capture (media-provenance-capture)
- WordPress: extends with attachment_id, schema_version, duration_ms (wpai-monitor-record), subject-only (no VC envelope)

Made-with: Cursor